### PR TITLE
Fixed the immediate bug that was preventing it from deserializing. 

### DIFF
--- a/native/hexpds_dagcbor_internal/src/lib.rs
+++ b/native/hexpds_dagcbor_internal/src/lib.rs
@@ -13,10 +13,10 @@ mod atoms {
 
 #[rustler::nif]
 fn encode_dag_cbor(env: Env, json: String) -> Term {
-    let parsed_json = match from_str(&json) {
-        Ok(json) => json,
-        Err(e) => return (atoms::error(), format!("Failed to parse JSON: {}", e)).encode(env),
-    };
+        let parsed_json: serde_json::Value = match from_str(&json) {
+            Ok(json) => json,
+            Err(e) => return (atoms::error(), format!("Failed to parse JSON: {}", e)).encode(env),
+        };
 
     let cbor_data = match to_vec(&parsed_json) {
         Ok(data) => data,


### PR DESCRIPTION
Don't have all the Elixir stuff set up to test with, but my isolated test of the following code pulled out into its own program works.

If you're just directly piping from json to cbor, this is probably sufficient, but if you do want some sort of internal type representation you'll probably want to set up some structs for the data. Looks like there's the [serde_rustler](https://github.com/sunny-g/serde_rustler/tree/master) crate to get stuff into Elixir data types, if you hadn't already found it.